### PR TITLE
Handle trailing slash in AMQP url

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ HunterGate(
    LOCAL
 )
 
-project(koinos_mq VERSION 1.0.0 LANGUAGES CXX C)
+project(koinos_mq VERSION 1.0.1 LANGUAGES CXX C)
 
 #
 # CONFIGURATION

--- a/libraries/mq/message_broker.cpp
+++ b/libraries/mq/message_broker.cpp
@@ -278,7 +278,7 @@ error_code message_broker_impl::connect(
       code = connect_lockfree(
          std::string( cinfo.host ),
          uint16_t( cinfo.port ),
-         *cinfo.vhost ? std::string( cinfo.vhost ) : std::string( "/" ),
+         std::string( *cinfo.vhost ? cinfo.vhost : "/" ),
          std::string( cinfo.user ),
          std::string( cinfo.password )
       );

--- a/libraries/mq/message_broker.cpp
+++ b/libraries/mq/message_broker.cpp
@@ -278,7 +278,7 @@ error_code message_broker_impl::connect(
       code = connect_lockfree(
          std::string( cinfo.host ),
          uint16_t( cinfo.port ),
-         std::string( "/" ) + cinfo.vhost,
+         *cinfo.vhost ? std::string( cinfo.vhost ) : std::string( "/" ),
          std::string( cinfo.user ),
          std::string( cinfo.password )
       );


### PR DESCRIPTION
Resolves #36.

## Brief description
Properly handle AMQP URL when trailing slash exists or is omitted, as well as when there is a non-default vhost.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
❯ ./programs/koinos_mq_client/Debug/koinos_mq_client -a amqp://guest:guest@localhost:5672
2022-11-23 16:00:05.210153 (mq_client.Huiiq) [main.cpp:68] <info>: connected

❯ ./programs/koinos_mq_client/Debug/koinos_mq_client -a amqp://guest:guest@localhost:5672/
2022-11-23 16:00:07.210742 (mq_client.A48O1) [main.cpp:68] <info>: connected

❯ ./programs/koinos_mq_client/Debug/koinos_mq_client -a amqp://guest:guest@localhost:5672/harbinger
2022-11-23 16:00:09.824831 (mq_client.d6wRX) [main.cpp:68] <info>: connected
```
